### PR TITLE
Iron Armor Defense boost

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: kykinite-artifacts
+        name: kykinite-irontest-artifacts
         path: build/libs

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Upload build artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: kykinite-irontest-artifacts
+        name: kykinite-artifacts
         path: build/libs

--- a/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
+++ b/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
@@ -44,7 +44,6 @@ public class BaseKykiniteArmorItem extends ArmorItem {
         builder.put(EntityAttributes.GENERIC_MAX_HEALTH, new EntityAttributeModifier(uUID, "Armor Health modifier", (double)this.maxHealth, EntityAttributeModifier.Operation.ADDITION));
         builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(uUID, "Armor Attack modifier", (double)this.attackDamage, EntityAttributeModifier.Operation.MULTIPLY_BASE));
         builder.put(EntityAttributes.GENERIC_MOVEMENT_SPEED, new EntityAttributeModifier(uUID, "Armor Movement Speed modifier", (double)this.movementSpeed, EntityAttributeModifier.Operation.ADDITION));
-        builder.put(EntityAttributes.GENERIC_ATTACK_SPEED, new EntityAttributeModifier(uUID, "Armor Attack Speed modifier", (double)this.attackDamage, EntityAttributeModifier.Operation.ADDITION));
         builder.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(uUID, "Armor Percentage modifier", (double)this.armorPercentBoost, EntityAttributeModifier.Operation.MULTIPLY_BASE));
          this.attributeModifiers = builder.build();
 
@@ -76,10 +75,7 @@ public class BaseKykiniteArmorItem extends ArmorItem {
     public float getKnockbackResistance(){
         return this.knockbackResistance;
     }
-
-    public float getAttackSpeed(){
-        return this.attackSpeed;
-    }
+   
         public float getArmorPercentBoost(){
     return this.armorPercentBoost
     }

--- a/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
+++ b/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
@@ -77,7 +77,7 @@ public class BaseKykiniteArmorItem extends ArmorItem {
     }
    
         public float getArmorPercentBoost(){
-    return this.armorPercentBoost
+    return this.armorPercentBoost;
     }
 }
 

--- a/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
+++ b/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
@@ -35,7 +35,7 @@ public class BaseKykiniteArmorItem extends ArmorItem {
         this.maxHealth = material.getMaxHealth();
         this.attackDamage = material.getAttackDamage();
         this.movementSpeed = material.getMovementSpeed();
-        this.attackSpeed = material.getAttackSpeed();
+        this.armorPercentBoost = material.getArmorPercentBoost();
         ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
         UUID uUID = MODIFIERS[slot.getEntitySlotId()];
         builder.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(uUID, "Armor modifier", (double)this.protection, EntityAttributeModifier.Operation.ADDITION));

--- a/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
+++ b/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorItem.java
@@ -21,7 +21,7 @@ public class BaseKykiniteArmorItem extends ArmorItem {
     private final float movementSpeed;
     private final float attackDamage;
 
-    private final float attackSpeed;
+    private final float armorPercentBoost;
 
     public BaseKykiniteArmorMaterial type;
     public Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
@@ -45,6 +45,7 @@ public class BaseKykiniteArmorItem extends ArmorItem {
         builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeModifier(uUID, "Armor Attack modifier", (double)this.attackDamage, EntityAttributeModifier.Operation.MULTIPLY_BASE));
         builder.put(EntityAttributes.GENERIC_MOVEMENT_SPEED, new EntityAttributeModifier(uUID, "Armor Movement Speed modifier", (double)this.movementSpeed, EntityAttributeModifier.Operation.ADDITION));
         builder.put(EntityAttributes.GENERIC_ATTACK_SPEED, new EntityAttributeModifier(uUID, "Armor Attack Speed modifier", (double)this.attackDamage, EntityAttributeModifier.Operation.ADDITION));
+        builder.put(EntityAttributes.GENERIC_ARMOR, new EntityAttributeModifier(uUID, "Armor Percentage modifier", (double)this.armorPercentBoost, EntityAttributeModifier.Operation.MULTIPLY_BASE));
          this.attributeModifiers = builder.build();
 
     }
@@ -78,6 +79,9 @@ public class BaseKykiniteArmorItem extends ArmorItem {
 
     public float getAttackSpeed(){
         return this.attackSpeed;
+    }
+        public float getArmorPercentBoost(){
+    return this.armorPercentBoost
     }
 }
 

--- a/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorMaterial.java
+++ b/src/main/java/com/dev/siuolplex/armor/BaseKykiniteArmorMaterial.java
@@ -9,5 +9,5 @@ public interface BaseKykiniteArmorMaterial extends ArmorMaterial {
 
     float getMovementSpeed();
 
-    float getAttackSpeed();
+    float getArmorPercentBoost();
 }

--- a/src/main/java/com/dev/siuolplex/armor/DiamondKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/DiamondKykiniteArmorMaterials.java
@@ -67,7 +67,7 @@ public class DiamondKykiniteArmorMaterials implements BaseKykiniteArmorMaterial 
 
 
     @Override
-    public float getAttackSpeed() {
-        return 0;
+    public float getArmorPercentBoost(){
+        return 0.0F
     }
 }

--- a/src/main/java/com/dev/siuolplex/armor/DiamondKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/DiamondKykiniteArmorMaterials.java
@@ -68,6 +68,6 @@ public class DiamondKykiniteArmorMaterials implements BaseKykiniteArmorMaterial 
 
     @Override
     public float getArmorPercentBoost(){
-        return 0.0F
+        return 0.0F;
     }
 }

--- a/src/main/java/com/dev/siuolplex/armor/GoldKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/GoldKykiniteArmorMaterials.java
@@ -67,6 +67,6 @@ public class GoldKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
     }
     @Override
     public float getArmorPercentBoost(){
-        return 0.0F
+        return 0.0F;
     }
 }

--- a/src/main/java/com/dev/siuolplex/armor/GoldKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/GoldKykiniteArmorMaterials.java
@@ -66,7 +66,7 @@ public class GoldKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
         return 0;
     }
     @Override
-    public float getAttackSpeed() {
-        return 0;
+    public float getArmorPercentBoost(){
+        return 0.0F
     }
-    }
+}

--- a/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
@@ -61,8 +61,8 @@ public class IronKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
     public float getMovementSpeed(){return 0.0F;}
 
     @Override
-    public float getAttackSpeed() {
-        return 0.2F;
+    public float getArmorPercentBoost(){
+        return 0.25F
     }
 }
 

--- a/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
@@ -28,7 +28,7 @@ public class IronKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
 
     @Override
     public SoundEvent getEquipSound() {
-        return Soun;dEvents.ITEM_ARMOR_EQUIP_IRON;
+        return SoundEvents.ITEM_ARMOR_EQUIP_IRON;
     }
 
     @Override

--- a/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/IronKykiniteArmorMaterials.java
@@ -28,7 +28,7 @@ public class IronKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
 
     @Override
     public SoundEvent getEquipSound() {
-        return SoundEvents.ITEM_ARMOR_EQUIP_IRON;
+        return Soun;dEvents.ITEM_ARMOR_EQUIP_IRON;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class IronKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
 
     @Override
     public float getArmorPercentBoost(){
-        return 0.25F
+        return 0.25F;
     }
 }
 

--- a/src/main/java/com/dev/siuolplex/armor/NetheriteKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/NetheriteKykiniteArmorMaterials.java
@@ -66,7 +66,7 @@ public class NetheriteKykiniteArmorMaterials implements BaseKykiniteArmorMateria
     }
     @Override
     public float getArmorPercentBoost(){
-        return 0.0F
+        return 0.0F;
     }
 
 }

--- a/src/main/java/com/dev/siuolplex/armor/NetheriteKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/NetheriteKykiniteArmorMaterials.java
@@ -65,8 +65,8 @@ public class NetheriteKykiniteArmorMaterials implements BaseKykiniteArmorMateria
         return 0;
     }
     @Override
-    public float getAttackSpeed() {
-        return 0;
+    public float getArmorPercentBoost(){
+        return 0.0F
     }
 
 }

--- a/src/main/java/com/dev/siuolplex/armor/PoweredQuartzKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/PoweredQuartzKykiniteArmorMaterials.java
@@ -61,8 +61,8 @@ public class PoweredQuartzKykiniteArmorMaterials implements BaseKykiniteArmorMat
     public float getMovementSpeed(){return 0.025F;}
 
     @Override
-    public float getAttackSpeed() {
-        return 0;
+    public float getArmorPercentBoost(){
+        return 0.0F
     }
 
 }

--- a/src/main/java/com/dev/siuolplex/armor/PoweredQuartzKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/PoweredQuartzKykiniteArmorMaterials.java
@@ -62,7 +62,7 @@ public class PoweredQuartzKykiniteArmorMaterials implements BaseKykiniteArmorMat
 
     @Override
     public float getArmorPercentBoost(){
-        return 0.0F
+        return 0.0F;
     }
 
 }

--- a/src/main/java/com/dev/siuolplex/armor/QuartzKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/QuartzKykiniteArmorMaterials.java
@@ -61,7 +61,7 @@ public class QuartzKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
 
     @Override
     public float getArmorPercentBoost(){
-        return 0.0F
+        return 0.0F;
     }
 }
 

--- a/src/main/java/com/dev/siuolplex/armor/QuartzKykiniteArmorMaterials.java
+++ b/src/main/java/com/dev/siuolplex/armor/QuartzKykiniteArmorMaterials.java
@@ -60,8 +60,8 @@ public class QuartzKykiniteArmorMaterials implements BaseKykiniteArmorMaterial {
     public float getMovementSpeed(){return 0.0F;}
 
     @Override
-    public float getAttackSpeed() {
-        return 0;
+    public float getArmorPercentBoost(){
+        return 0.0F
     }
 }
 


### PR DESCRIPTION
Changes Iron armor to do a boost in defense instead of attack speed it currently does. 
This only exists for 1.2.0